### PR TITLE
Forward dots

### DIFF
--- a/src/main/eval.c
+++ b/src/main/eval.c
@@ -2770,31 +2770,12 @@ SEXP attribute_hidden promiseArgs(SEXP el, SEXP rho)
 
     while(el != R_NilValue) {
 
-	/* If we have a ... symbol, we look to see what it is bound to.
-	 * If its binding is Null (i.e. zero length)
-	 * we just ignore it and return the cdr with all its
-	 * expressions promised; if it is bound to a ... list
-	 * of promises, we repromise all the promises and then splice
-	 * the list of resulting values into the return value.
-	 * Anything else bound to a ... symbol is an error
-	 */
-
-	/* Is this double promise mechanism really needed? */
-
+	// Simply forward dots found in the previous frame
 	if (CAR(el) == R_DotsSymbol) {
 	    PROTECT(h = findVar(CAR(el), rho));
-	    if (TYPEOF(h) == DOTSXP || h == R_NilValue) {
-		while (h != R_NilValue) {
-			if (TYPEOF(CAR(h)) == SYMSXP || TYPEOF(CAR(h)) == LANGSXP)
-				SETCDR(tail, CONS(mkPROMISE(CAR(h), rho), R_NilValue));
-			else
-				SETCDR(tail, CONS(CAR(h), R_NilValue));
-		    tail = CDR(tail);
-		    COPY_TAG(tail, h);
-		    h = CDR(h);
-		}
-	    }
-	    else if (h != R_MissingArg)
+		if (TYPEOF(h) == DOTSXP)
+			SETCDR(tail, h);
+	    else if (h != R_MissingArg && h != R_NilValue)
 		error(_("'...' used in an incorrect context"));
 	    UNPROTECT(1); /* h */
 	}

--- a/src/main/eval.c
+++ b/src/main/eval.c
@@ -2785,7 +2785,10 @@ SEXP attribute_hidden promiseArgs(SEXP el, SEXP rho)
 	    PROTECT(h = findVar(CAR(el), rho));
 	    if (TYPEOF(h) == DOTSXP || h == R_NilValue) {
 		while (h != R_NilValue) {
-		    SETCDR(tail, CONS(mkPROMISE(CAR(h), rho), R_NilValue));
+			if (TYPEOF(CAR(h)) == SYMSXP || TYPEOF(CAR(h)) == LANGSXP)
+				SETCDR(tail, CONS(mkPROMISE(CAR(h), rho), R_NilValue));
+			else
+				SETCDR(tail, CONS(CAR(h), R_NilValue));
 		    tail = CDR(tail);
 		    COPY_TAG(tail, h);
 		    h = CDR(h);


### PR DESCRIPTION
@hadley We might suggest the first commit in this patch to Luke and Tomas as well.

With the first commit, promises in dots are forwarded in a new pairlist to save on promise allocations. This seems to be backward compatible with all packages I tried.

With the second commit, dots are forwarded as is to save on cons allocations. While most R code seems to work fine, this is not compatible with lazyeval :/.