### PR TITLE
 Take `message` instead of `msg` parameter in condition ctors 

### DIFF
--- a/src/library/base/R/conditions.R
+++ b/src/library/base/R/conditions.R
@@ -111,12 +111,12 @@ simpleWarning <- function(message, call = NULL) {
     structure(list(message=as.character(message), call = call), class=class)
 }
 
-errorCondition <- function(msg, ..., class = NULL, call = NULL)
-    structure(list(message = msg, call = call, ...),
+errorCondition <- function(message, ..., class = NULL, call = NULL)
+    structure(list(message = message, call = call, ...),
               class = c(class, "error", "condition"))
 
-warningCondition <- function(msg, ..., class = NULL, call = NULL)
-    structure(list(message = msg, call = call, ...),
+warningCondition <- function(message, ..., class = NULL, call = NULL)
+    structure(list(message = message, call = call, ...),
               class = c(class, "warning", "condition"))
 
 conditionMessage <- function(c) UseMethod("conditionMessage")

--- a/src/library/base/man/conditions.Rd
+++ b/src/library/base/man/conditions.Rd
@@ -56,8 +56,8 @@ simpleError    (message, call = NULL)
 simpleWarning  (message, call = NULL)
 simpleMessage  (message, call = NULL)
 
-errorCondition(msg, ..., class = NULL, call = NULL)
-warningCondition(msg, ..., class = NULL, call = NULL)
+errorCondition(message, ..., class = NULL, call = NULL)
+warningCondition(message, ..., class = NULL, call = NULL)
 
 \method{as.character}{condition}(x, \dots)
 \method{as.character}{error}(x, \dots)


### PR DESCRIPTION
This way users cannot pass `message` field and create a condition containing redundant components. With current trunk:

```r
unclass(errorCondition(msg = "foo", message = "bam"))
#> $message
#> [1] "foo"
#>
#> $call
#> NULL
#>
#> $message
#> [1] "bam"
```

This is also consistent with the simple warning/error constructors.