### PR TITLE
[PATCH 2] Fix print dispatch consistency

### DIFF
--- a/tests/print-tests.R
+++ b/tests/print-tests.R
@@ -356,3 +356,52 @@ list(list(x))
 print(list(list(x)))
 ##
 rm(x)
+
+
+## Print and auto-print are consistent when user has defined S3
+## methods in the global environment
+##
+## Data frames:
+print.data.frame <- function(x, ...) {
+    cat("dispatched to print.data.frame\n")
+    base::print.data.frame(x, ...)
+}
+x <- data.frame(x = 1:3)
+x
+print(x)
+## FIXME: Recursive case doesn't dispatch to user functions
+list(x, list(x))
+print(list(x, list(x)))
+##
+## Functions:
+print.function <- function(x, ...) {
+    cat("dispatched to print.function\n")
+    NextMethod()
+}
+old <- compiler::enableJIT(0) # Avoid bytecode diffs
+x <- function(x) x
+x
+print(x)
+## FIXME: Recursive case doesn't dispatch to user functions
+list(x, list(x))
+print(list(x, list(x)))
+##
+## Lists:
+print.list <- function(x, ...) {
+    cat("dispatched to print.list\n")
+    NextMethod()
+}
+list(1)
+print(list(1))
+list(1, list(1))
+print(list(1, list(1)))
+##
+compiler::enableJIT(old)
+rm(print.data.frame, print.function, print.list, x)
+
+
+## Can print lists containing the missing argument
+x <- alist(, foo = )
+x
+print(x)
+rm(x)

--- a/tests/print-tests.Rout.save
+++ b/tests/print-tests.Rout.save
@@ -1024,3 +1024,161 @@ attr(,"foo")attr(,"bar")
 > ##
 > rm(x)
 > 
+> 
+> ## Print and auto-print are consistent when user has defined S3
+> ## methods in the global environment
+> ##
+> ## Data frames:
+> print.data.frame <- function(x, ...) {
++     cat("dispatched to print.data.frame\n")
++     base::print.data.frame(x, ...)
++ }
+> x <- data.frame(x = 1:3)
+> x
+dispatched to print.data.frame
+  x
+1 1
+2 2
+3 3
+> print(x)
+dispatched to print.data.frame
+  x
+1 1
+2 2
+3 3
+> ## FIXME: Recursive case doesn't dispatch to user functions
+> list(x, list(x))
+[[1]]
+dispatched to print.data.frame
+  x
+1 1
+2 2
+3 3
+
+[[2]]
+[[2]][[1]]
+dispatched to print.data.frame
+  x
+1 1
+2 2
+3 3
+
+
+> print(list(x, list(x)))
+[[1]]
+  x
+1 1
+2 2
+3 3
+
+[[2]]
+[[2]][[1]]
+  x
+1 1
+2 2
+3 3
+
+
+> ##
+> ## Functions:
+> print.function <- function(x, ...) {
++     cat("dispatched to print.function\n")
++     NextMethod()
++ }
+> old <- compiler::enableJIT(0) # Avoid bytecode diffs
+> x <- function(x) x
+> x
+dispatched to print.function
+function (x) 
+x
+> print(x)
+dispatched to print.function
+function (x) 
+x
+> ## FIXME: Recursive case doesn't dispatch to user functions
+> list(x, list(x))
+[[1]]
+dispatched to print.function
+function (x) 
+x
+
+[[2]]
+[[2]][[1]]
+dispatched to print.function
+function (x) 
+x
+
+
+> print(list(x, list(x)))
+[[1]]
+function (x) 
+x
+
+[[2]]
+[[2]][[1]]
+function (x) 
+x
+
+
+> ##
+> ## Lists:
+> print.list <- function(x, ...) {
++     cat("dispatched to print.list\n")
++     NextMethod()
++ }
+> list(1)
+dispatched to print.list
+[[1]]
+[1] 1
+
+> print(list(1))
+dispatched to print.list
+[[1]]
+[1] 1
+
+> list(1, list(1))
+dispatched to print.list
+[[1]]
+[1] 1
+
+[[2]]
+dispatched to print.list
+[[2]][[1]]
+[1] 1
+
+
+> print(list(1, list(1)))
+dispatched to print.list
+[[1]]
+[1] 1
+
+[[2]]
+dispatched to print.list
+[[2]][[1]]
+[1] 1
+
+
+> ##
+> compiler::enableJIT(old)
+[1] 0
+> rm(print.data.frame, print.function, print.list, x)
+> 
+> 
+> ## Can print lists containing the missing argument
+> x <- alist(, foo = )
+> x
+[[1]]
+
+
+$foo
+
+
+> print(x)
+[[1]]
+
+
+$foo
+
+
+> rm(x)
+> 


### PR DESCRIPTION
Requires #23.

This patch is a follow-up to r76565
(https://github.com/wch/r-source/commit/e06aa530). It enhances the
consistency between print and autoprint by calling `print()` whenever
a method is defined for an object, even when OBJECT is unset. With
this second change, dispatch consistently reaches S3 methods for base
types. Previously, it would only reach `print.function()` because of
special-casing in the dispatch code:

```r
print.list <- function(x, ...) {
    str(x, max.level = 2)
}

### Before

list(list(1))
#> [[1]]
#> [[1]][[1]]
#> [1] 1


### After

list(list(1))
#> List of 1
#>  $ :List of 1
#>   ..$ : num 1
```

Since we only call the R level `print()` when a method is defined,
autoprint doesn't bump the namedness of objects unless it is
necessary.
