### PR TITLE
[PATCH 3] Forward calling environment

### DIFF
--- a/src/library/base/R/print.R
+++ b/src/library/base/R/print.R
@@ -46,7 +46,7 @@ print.default <- function(x, digits = NULL, quote = TRUE, na.print = NULL,
     isString <- function(x) is.character(x) && length(x) == 1 && !is.na(x)
     stopifnot(isString(indexTag))
 
-    .Internal(print.default(x, indexTag, args, missings))
+    .Internal(print.default(x, parent.frame(), indexTag, args, missings))
 }
 
 prmatrix <-

--- a/src/main/names.c
+++ b/src/main/names.c
@@ -683,7 +683,7 @@ FUNTAB R_FunTab[] =
 {"dump",	do_dump,	0,	111,	5,	{PP_FUNCALL, PREC_FN,	0}},
 {"quit",	do_quit,	0,	111,	3,	{PP_FUNCALL, PREC_FN,	0}},
 {"readline",	do_readln,	0,	11,	1,	{PP_FUNCALL, PREC_FN,	0}},
-{"print.default",do_printdefault,0,	111,	4,	{PP_FUNCALL, PREC_FN,	0}},
+{"print.default",do_printdefault,0,	111,	5,	{PP_FUNCALL, PREC_FN,	0}},
 {"prmatrix",	do_prmatrix,	0,	111,	6,	{PP_FUNCALL, PREC_FN,	0}},
 {"gc",		do_gc,		0,	11,	3,	{PP_FUNCALL, PREC_FN,	0}},
 {"gcinfo",	do_gcinfo,	0,	11,	1,	{PP_FUNCALL, PREC_FN,	0}},

--- a/src/main/print.c
+++ b/src/main/print.c
@@ -224,9 +224,10 @@ SEXP attribute_hidden do_printdefault(SEXP call, SEXP op, SEXP args, SEXP rho)
     checkArity(op, args);
 
     SEXP x = CAR(args); args = CDR(args);
+    SEXP env = CAR(args); args = CDR(args);
 
     R_PrintData data;
-    PrintInit(&data, rho);
+    PrintInit(&data, env);
 
     /* Index tag is type-checked at R level */
     SEXP oldtagbuf = PROTECT(mkChar(tagbuf));

--- a/tests/print-tests.R
+++ b/tests/print-tests.R
@@ -369,7 +369,6 @@ print.data.frame <- function(x, ...) {
 x <- data.frame(x = 1:3)
 x
 print(x)
-## FIXME: Recursive case doesn't dispatch to user functions
 list(x, list(x))
 print(list(x, list(x)))
 ##
@@ -382,7 +381,6 @@ old <- compiler::enableJIT(0) # Avoid bytecode diffs
 x <- function(x) x
 x
 print(x)
-## FIXME: Recursive case doesn't dispatch to user functions
 list(x, list(x))
 print(list(x, list(x)))
 ##

--- a/tests/print-tests.Rout.save
+++ b/tests/print-tests.Rout.save
@@ -1046,7 +1046,6 @@ dispatched to print.data.frame
 1 1
 2 2
 3 3
-> ## FIXME: Recursive case doesn't dispatch to user functions
 > list(x, list(x))
 [[1]]
 dispatched to print.data.frame
@@ -1066,6 +1065,7 @@ dispatched to print.data.frame
 
 > print(list(x, list(x)))
 [[1]]
+dispatched to print.data.frame
   x
 1 1
 2 2
@@ -1073,6 +1073,7 @@ dispatched to print.data.frame
 
 [[2]]
 [[2]][[1]]
+dispatched to print.data.frame
   x
 1 1
 2 2
@@ -1095,7 +1096,6 @@ x
 dispatched to print.function
 function (x) 
 x
-> ## FIXME: Recursive case doesn't dispatch to user functions
 > list(x, list(x))
 [[1]]
 dispatched to print.function
@@ -1111,11 +1111,13 @@ x
 
 > print(list(x, list(x)))
 [[1]]
+dispatched to print.function
 function (x) 
 x
 
 [[2]]
 [[2]][[1]]
+dispatched to print.function
 function (x) 
 x
 


### PR DESCRIPTION
Requires #24.

This patch is another attempt at getting `print()` to forward the
original calling environment when recursing back to R. This patch was
already proposed in PR 17398, and rejected at the time. I will try to
better explain the motivation behind it.

Currently, autoprint passes the current environment (an execution
environment if called from the stack browser, or the global env if
called from the console) to the native print routine. However, the R
function print() passes its own execution environment rather than the
environment of its caller. Since environment inherits from the base
namespace, this prevents the recursive case of print() from
dispatching to user-defined methods when the methods are also defined
in base:

```r
print.function <- function(x, ...) {
    cat("<FN-DISPATCHED>\n")
    NextMethod()
}

### Correct before and after

identity
#> <FN-DISPATCHED>
#> function (x)
#> x
#> <bytecode: 0x7ffb006cfc00>
#> <environment: namespace:base>

print(identity)
#> <FN-DISPATCHED>
#> function (x)
#> x
#> <bytecode: 0x7ffb006cfc00>
#> <environment: namespace:base>

list(identity)
#> [[1]]
#> <FN-DISPATCHED>
#> function (x)
#> x
#> <bytecode: 0x7ffb006cfc00>
#> <environment: namespace:base>


### Before

print(list(identity))
#> [[1]]
#> function (x)
#> x
#> <bytecode: 0x7ffb006cfc00>
#> <environment: namespace:base>


### After

print(list(identity))
#> [[1]]
#> <FN-DISPATCHED>
#> function (x)
#> x
#> <bytecode: 0x7fdfa20e9e00>
#> <environment: namespace:base>


# Similarly for data frames:

print.data.frame <- function(x, ...) {
    cat("<DF-DISPATCHED>\n")
    base::print.data.frame(x, ...)
}

### Before

print(list(data.frame(x = 1)))
#> [[1]]
#>   x
#> 1 1


### After

print(list(data.frame(x = 1)))
#> [[1]]
#> <DF-DISPATCHED>
#>   x
#> 1 1
```

Note that if a print method is defined for `list` that calls
`print.default()` again, this forces a recursion through print().  In
this case, auto-printing lists used to disrupt dispatch, which is also
fixed by patch 3:

```r
print.list <- function(x, ...) {
	cat(sprintf("<list: %d elements>\n", length(x)))
	NextMethod()
}

### Before:

list(identity, 2)
#> <list: 2 elements>
#> [[1]]
#> function (x)
#> x
#> <bytecode: 0x7f9e310c9a00>
#> <environment: namespace:base>
#>
#> [[2]]
#> [1] 2


### After:

list(identity, 2)
#> <list: 2 elements>
#> [[1]]
#> <FN-DISPATCHED>
#> function (x)
#> x
#> <bytecode: 0x7f9e310c9a00>
#> <environment: namespace:base>
#>
#> [[2]]
#> [1] 2
```

In essence, this patch ensures lexical scoping of method dispatch by
properly forwarding the dispatch context throughout recursion.
