### PR TITLE
Add `classes` argument to `suppressWarnings()`

### DIFF
--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -103,6 +103,9 @@
       \item Added an argument \code{add_datalist(*, small.size = 0)} to
       allow the creation of a \file{data/datalist} file even when the
       total size of the data sets is small.
+
+      \item New \code{classes} argument for \code{suppressWarnings()} to
+      selectively suppress warnings that inherit from particular classes.
     }
   }
 

--- a/src/library/base/R/conditions.R
+++ b/src/library/base/R/conditions.R
@@ -83,10 +83,11 @@ withCallingHandlers <- function(expr, ...) {
     expr
 }
 
-suppressWarnings <- function(expr) {
+suppressWarnings <- function(expr, classes = "warning") {
     withCallingHandlers(expr,
-                        warning=function(w)
-                            invokeRestart("muffleWarning"))
+                        warning = function(w)
+			    if (inherits(w, classes))
+				invokeRestart("muffleWarning"))
 }
 
 

--- a/src/library/base/man/warning.Rd
+++ b/src/library/base/man/warning.Rd
@@ -14,7 +14,7 @@
 \usage{
 warning(\dots, call. = TRUE, immediate. = FALSE, noBreaks. = FALSE,
         domain = NULL)
-suppressWarnings(expr)
+suppressWarnings(expr, classes = "warning")
 }
 \arguments{
   \item{\dots}{zero or more objects which can be coerced to character
@@ -29,6 +29,8 @@ suppressWarnings(expr)
   \item{expr}{expression to evaluate.}
   \item{domain}{see \code{\link{gettext}}.  If \code{NA}, messages will
     not be translated, see also the note in \code{\link{stop}}.}
+  \item{classes}{character, indicating which classes of warnings should
+    be suppressed.}
 }
 \details{
   The result \emph{depends} on the value of

--- a/tests/reg-tests-1d.R
+++ b/tests/reg-tests-1d.R
@@ -3106,6 +3106,18 @@ tools::assertError(options(warn = 1+.Machine$integer.max))
 ## "worked" and gave problems later in R <= 3.6.1
 
 
+## Can selectively suppress warnings
+w <- function(class) {
+    w <- simpleWarning("warned")
+    w <- structure(w, class = c(class, class(w)))
+    warning(w)
+}
+catch <- function(expr) tryCatch({ expr; FALSE }, warning = function(...) TRUE)
+stopifnot(!catch(suppressWarnings(w("foo"))))
+stopifnot(!catch(suppressWarnings(w("foo"), classes = c("bar", "foo"))))
+stopifnot(catch(suppressWarnings(w("foo"), classes = c("bar", "baz"))))
+rm(w, catch)
+
 
 ## keep at end
 rbind(last =  proc.time() - .pt,


### PR DESCRIPTION
The attached patch adds a `classes` argument to `suppressWarnings()`,
similar to the `classes` argument of `tools::assertWarning()`. The
goal is to make it easy to selectively suppress warnings, which should
in turn encourage package developers to throw classed warnings.

This patch requires #30 to be merged.